### PR TITLE
Add automatic build and deploy on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+sudo: required
+dist: trusty
+os: linux
+language: minimal
+cache:
+  directories:
+  - depends
+  - $HOME/.ccache
+env:
+  global:
+    - SDK_URL=https://bitcoincore.org/depends-sources/sdks
+    - CCACHE_SIZE=100M
+    - CCACHE_TEMPDIR=/tmp/.ccache-temp
+    - CCACHE_COMPRESS=1
+    - MAKEJOBS="-j2"
+    - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
+    - BASE_PACKAGES="zip git build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils curl libboost-all-dev libdb4.8-dev libdb4.8++-dev libminiupnpc-dev libzmq3-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev"
+  matrix:
+# ARM32
+    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf python3-pip" HEXXCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+# ARM64
+    - HOST=aarch64-linux-gnu PACKAGES="g++-aarch64-linux-gnu python3-pip" HEXXCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+# Win32
+    - HOST=i686-w64-mingw32 PACKAGES="python3 nsis g++-mingw-w64-i686 mingw-w64-i686-dev" HEXXCOIN_CONFIG="--enable-reduce-exports"
+# Win64
+    - HOST=x86_64-w64-mingw32 PACKAGES="python3 nsis g++-mingw-w64-x86-64 mingw-w64-x86-64-dev" HEXXCOIN_CONFIG="--enable-reduce-exports"
+# x86_64 Linux
+    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq" HEXXCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports"
+# Cross-Mac
+    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" HEXXCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror" OSX_SDK=10.11
+
+before_install:
+    - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+install:
+    - sudo add-apt-repository -y ppa:bitcoin/bitcoin
+    - sudo apt-get update
+    - travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $BASE_PACKAGES
+    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
+before_script:
+    - unset CC; unset CXX
+    - cd $TRAVIS_BUILD_DIR
+    - mkdir -p depends/SDKs depends/sdk-sources
+    - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
+    - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
+script:
+    - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
+    - ./autogen.sh
+    - cd depends && make $MAKEJOBS
+    - cd $TRAVIS_BUILD_DIR && ./configure --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --cache-file=config.cache
+    - make $MAKEJOBS
+before_deploy:
+    - ./pre-deploy.sh
+deploy:
+  provider: releases
+  api_key:
+    secure: mXknyKRQnAlQsOeqhw99ZpiZCam4sh2QRQ/DyxQ0AUc9yLwEIKtF5TfsKm264tDgcpwzvq1vE+03x0PaT1ECWfIeBGzPMEER95hyKmv5qAsmhP1Btm4P3eHVo92WcgfTe9PO+/G6VJR2awGmOMcOnMWYc+ySIDJCDw5aQ61YpdgHIfW9TyXZRXeBOlOLEsTPZrPuNgZFbwGuXE5gPa6d/g2h0nihirL4yFgIDDf5dO5XL3ToXRX7tZpOWGjW30DpbDMUPpVvP5BupRkTNzfR5Wh/8idWTbjQKvptKs9eg2O1EpJpG4SMCR2U2WT0LfKsyytHHxzKZaWSZAD/oAsqHCCot/lL6oxYN4z1cX91EaxI04wU55416fTKSxkJHT9vUvrQh4atbj89LrD6ACV8p6nb1l3iCcguCRB9NWgVvb2LPfPsLVbT+8bKW2BLYnH+8nNZOnhsv0fov87cdgUDbqQi+instnYIWLTjXb8wBDuGPlp9LaEupdWZ4dj13tAbeSVuQxWRd2UbRfDhXmYncY2JXhvQWK+AVlT/ZKGGlvn7+16bsBKHqBp3uvjdp9U4E61IGFfeluXQ5TxqgUhbGOz+O5eAGxjzPsL5i2OiBUSPqIEBA4Sk54Jgg+Rx91e4kb/dwhrRLaO4b6f2lJ3wftneVj/XzmK9BW6K0KkQ45g=
+  file_glob: true
+  file: out/**/zip/*
+  skip_cleanup: true
+  on:
+    tags: true

--- a/pre-deploy.sh
+++ b/pre-deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+OUTDIR=$TRAVIS_BUILD_DIR/out/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
+mkdir -p $OUTDIR/bin
+
+if [[ $HOST = "i686-w64-mingw32" ]]; then
+  ARCHIVE_NAME="windows-x86.zip"
+elif [[ $HOST = "x86_64-w64-mingw32" ]]; then
+    ARCHIVE_NAME="windows-x64.zip"
+elif [[ $HOST = "arm-linux-gnueabihf" ]]; then
+    ARCHIVE_NAME="arm-x86.zip"
+elif [[ $HOST = "aarch64-linux-gnu" ]]; then
+    ARCHIVE_NAME="arm-x64.zip"
+elif [[ $HOST = "x86_64-unknown-linux-gnu" ]]; then
+    ARCHIVE_NAME="linux-x64.zip"
+elif [[ $HOST = "x86_64-apple-darwin11" ]]; then
+    ARCHIVE_NAME="osx-x64.zip"
+fi
+
+cp $TRAVIS_BUILD_DIR/src/qt/hexxcoin-qt $OUTDIR/bin/ || cp $TRAVIS_BUILD_DIR/src/qt/hexxcoin-qt.exe $OUTDIR/bin/ || echo "no QT Wallet"
+cp $TRAVIS_BUILD_DIR/src/hexxcoind $OUTDIR/bin/ || cp $TRAVIS_BUILD_DIR/src/hexxcoind.exe $OUTDIR/bin/
+cp $TRAVIS_BUILD_DIR/src/hexxcoin-cli $OUTDIR/bin/ || cp $TRAVIS_BUILD_DIR/src/hexxcoin-cli.exe $OUTDIR/bin/
+strip "$OUTDIR/bin"/* || echo "nothing to strip"
+ls -lah $OUTDIR/bin
+
+cd $OUTDIR/bin
+zip $ARCHIVE_NAME *
+
+mkdir -p $OUTDIR/zip
+mv $ARCHIVE_NAME $OUTDIR/zip
+
+sleep $[ ( $RANDOM % 6 )  + 1 ]s


### PR DESCRIPTION
This PR will add automatic builds on every commit.
Additionally resulting binaries are deployed as a github release if the commit is a tag.

Caching is used to speedup builds significantly.

**Notes:** Currently the whole `depends` directory is being cached and it is unclear to me if this will prevent updated depends files from being used.

TODO:
- [ ] Update the github release secure api key with a new one for the official repo